### PR TITLE
CI: Auto-assign reviewers to pull requests

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -1,0 +1,6 @@
+# Automatically assign PR to author and add all reviewers below.
+addAssignees: author
+addReviewers: true
+reviewers:
+  - abc
+  - esabol


### PR DESCRIPTION
When a new pull request is opened, this app will automatically add all of the listed reviewers as reviewers of the PR, and it will also assign the PR to the author.