### PR TITLE
FEAT: Add College of Creation bard subclass

### DIFF
--- a/Sources/TashasCauldronOfEverything/class-bard-tce.xml
+++ b/Sources/TashasCauldronOfEverything/class-bard-tce.xml
@@ -13,6 +13,46 @@
       </autolevel>
     <autolevel level="3">
         <feature optional="YES">
+          <name>Bard College: College of Creation</name>
+        <text>Bards believe the cosmos is a work of art—the creation of the first dragons and gods. That creative work included harmonies that continue to resound through existence today, a power known as the Song of Creation. The bards of the College of Creation draw on that primeval song through dance, music, and poetry, and their teachers share this lesson: “Before the sun and the moon, there was the Song, and its music awoke the first dawn. Its melodies so delighted the stones and trees that some of them gained a voice of their own. And now they sing too. Learn the Song, students, and you too can teach the mountains to sing and dance.”</text>
+		<text></text>
+        <text>Dwarves and gnomes often encourage their bards to become students of the Song of Creation. And among dragonborn, the Song of Creation is revered, for legends portray Bahamut and Tiamat—the greatest of dragons—as two of the song’s first singers.</text>
+        <text></text>
+        <text>Source: Tasha's Cauldron of Everything</text>
+        </feature>
+      </autolevel>
+    <autolevel level="3">
+        <feature optional="YES">
+          <name>College of Creation: Mote of Potential</name>
+        <text>3rd-level College of Creation feature</text>
+        <text>Whenever you give a creature a Bardic Inspiration die, you can utter a note from the Song of Creation to create a Tiny mote of potential, which orbits within 5 feet of that creature. The mote is intangible and invulnerable, and it lasts until the Bardic Inspiration die is lost. The mote looks like a musical note, a star, a flower, or another symbol of art or life that you choose.</text>
+        <text></text>
+        <text>When the creature uses the Bardic Inspiration die, the mote provides an additional effect based on whether the die benefits an ability check, an attack roll, or a saving throw, as detailed below:</text>
+        <text></text>
+        <text>Ability Check: When the creature rolls the Bardic Inspiration die to add it to an ability check, the creature can roll the Bardic Inspiration die again and choose which roll to use, as the mote pops and emits colorful, harmless sparks for a moment.</text>
+        <text></text>
+        <text>Attack Roll: Immediately after the creature rolls the Bardic Inspiration die to add it to an attack roll against a target, the mote thunderously shatters. The target and each creature of your choice that you can see within 5 feet of it must succeed on a Constitution saving throw against your spell save DC or take thunder damage equal to the number rolled on the Bardic Inspiration die.</text>
+        <text></text>
+        <text>Saving Throw: Immediately after the creature rolls the Bardic Inspiration die and adds it to a saving throw, the mote vanishes with the sound of soft music, causing the creature to gain temporary hit points equal to the number rolled on the Bardic Inspiration die plus your Charisma modifier (minimum of 1 temporary hit point).</text>
+        <text></text>
+        <text>Source: Tasha's Cauldron of Everything</text>
+        </feature>
+      </autolevel>
+    <autolevel level="3">
+        <feature optional="YES">
+          <name>College of Creation: Performance of Creation</name>
+        <text>3rd-level College of Creation feature</text>
+        <text>As an action, you can channel the magic of the Song of Creation to create one nonmagical item of your choice in an unoccupied space within 10 feet of you. The item must appear on a surface or in a liquid that can support it. The gp value of the item can’t be more than 20 times your bard level, and the item must be Medium or smaller. The item glimmers softly, and a creature can faintly hear music when touching it. The created item disappears after a number of hours equal to your proficiency bonus. For examples of items you can create, see the equipment chapter of the Player’s Handbook.</text>
+        <text></text>
+        <text>Once you create an item with this feature, you can’t do so again until you finish a long rest, unless you expend a spell slot of 2nd level or higher to use this feature again. You can have only one item created by this feature at a time; if you use this action and already have an item from this feature, the first one immediately vanishes.</text>
+        <text></text>
+        <text>The size of the item you can create with this feature increases by one size category when you reach 6th level (Large) and 14th level (Huge).</text>
+        <text></text>
+        <text>Source: Tasha's Cauldron of Everything</text>
+        </feature>
+      </autolevel>
+    <autolevel level="3">
+        <feature optional="YES">
           <name>Bard College: College of Eloquence</name>
         <text>Adherents of the College of Eloquence master the art of oratory. Persuasion is regarded as a high art, and a well-reasoned, well-spoken argument often proves more persuasive than facts. These bards wield a blend of logic and theatrical wordplay, winning over skeptics and detractors with logical arguments and plucking at heartstrings to appeal to the emotions of audiences.</text>
         <text></text>
@@ -50,6 +90,21 @@
       </autolevel>
     <autolevel level="6">
         <feature optional="YES">
+          <name>College of Creation: Animating Performance</name>
+        <text>6th-level College of Creation feature</text>
+        <text>As an action, you can animate one Large or smaller nonmagical item within 30 feet of you that isn’t being worn or carried. The animate item uses the Dancing Item stat block, which uses your proficiency bonus (PB). The item is friendly to you and your companions and obeys your commands. It lives for 1 hour, until it is reduced to 0 hit points, or until you die.</text>
+        <text></text>
+        <text>In combat, the item shares your initiative count, but it takes its turn immediately after yours. It can move and use its reaction on its own, but the only action it takes on its turn is the Dodge action, unless you take a bonus action on your turn to command it to take another action. That action can be one in its stat block or some other action. If you are incapacitated, the item can take any action of its choice, not just Dodge.</text>
+        <text></text>
+        <text>When you use your Bardic Inspiration feature, you can command the item as part of the same bonus action you use for Bardic Inspiration.</text>
+        <text></text>
+        <text>Once you animate an item with this feature, you can’t do so again until you finish a long rest, unless you expend a spell slot of 3rd level or higher to use this feature again. You can have only one item animated by this feature at a time; if you use this action and already have a dancing item from this feature, the first one immediately becomes inanimate.</text>
+        <text></text>
+        <text>Source: Tasha's Cauldron of Everything</text>
+        </feature>
+      </autolevel>
+    <autolevel level="6">
+        <feature optional="YES">
           <name>College of Eloquence: Unfailing Inspiration</name>
         <text>6th-level College of Eloquence feature</text>
         <text>Your inspiring words are so persuasive that others feel driven to succeed. When a creature adds one of your Bardic Inspiration dice to its ability check, attack roll, or saving throw and the roll fails, the creature can keep the Bardic Inspiration die.</text>
@@ -65,6 +120,17 @@
         <text>Once you use this feature, you can't use it again until you finish a long rest, unless you expend a spell slot to use it again.</text>
         <text></text>
         <text>Source: Tasha's Cauldron of Everything p. 29</text>
+        </feature>
+      </autolevel>
+    <autolevel level="14">
+        <feature optional="YES">
+          <name>College of Creation: Creative Crescendo</name>
+        <text>14th-level College of Creation feature</text>
+        <text>When you use your Performance of Creation feature, you can create more than one item at once. The number of items equals your Charisma modifier (minimum of two items). If you create an item that would exceed that number, you choose which of the previously created items disappears. Only one of these items can be of the maximum size you can create; the rest must be Small or Tiny.</text>
+        <text></text>
+        <text>You are no longer limited by gp value when creating items with Performance of Creation.</text>
+        <text></text>
+        <text>Source: Tasha's Cauldron of Everything</text>
         </feature>
       </autolevel>
     <autolevel level="14">


### PR DESCRIPTION
This adds all of the rules text for the College of Creation Bard College to Tasha's Cauldron of Everything as a sub-class for Bards.

Originally authored by @melinate on 2023-01-13.